### PR TITLE
St dp adaptation

### DIFF
--- a/2_rsdata/src/GEE_pull_functions.py
+++ b/2_rsdata/src/GEE_pull_functions.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env python2
-# -*- coding: utf-8 -*-
 """
 Google Earth Engine Reflectance Pull Functions
 Created on Mon Apr  9 14:24:13 2018
 @author: simontopp
 """
+import time
+import ee
 
 # Add filler panchromatic band to landsat 5 images.
 

--- a/2_rsdata/src/LakeExport.py
+++ b/2_rsdata/src/LakeExport.py
@@ -5,10 +5,10 @@ Created on Tue Feb 27 12:07:02 2018
 
 @author: simontopp
 """
-#%%
 import ee
-from GEE_pull_functions import maximum_no_of_tasks
-
+# Can't import because of variable references, #TODO revamp functions to import as module
+#from GEE_pull_functions import maximum_no_of_tasks, dpBuff, RefPull
+exec(open('2_rsdata/src/GEE_pull_functions.py').read())
 ee.Initialize()
 
 #water = ee.Image("JRC/GSW1_1/GlobalSurfaceWater").select('occurrence').gt(80)
@@ -23,16 +23,13 @@ ee.Initialize()
 #CONUS Boundary
 us = ee.FeatureCollection("USDOS/LSIB_SIMPLE/2017")\
     .filterMetadata('country_na', 'equals', 'United States')
-
+#US States
 states = ee.FeatureCollection("TIGER/2018/States")
 
 ## WRS Tiles in descending (daytime) mode for CONUS
 wrs = ee.FeatureCollection('users/sntopp/wrs2_asc_desc')\
-    .filterBounds(dp)\
     .filterMetadata('MODE', 'equals', 'D')
     
-
-
 #%%
 dummyBands = ee.Image(-99).rename('Null_CS')\
     .addBands(ee.Image(-99).rename('Null_TIR2'))
@@ -60,37 +57,27 @@ ls = ee.ImageCollection(ls5.merge(ls7).merge(ls8))\
     .filter(ee.Filter.lt('CLOUD_COVER', 75))\
     .filterBounds(us)  
 
-
-## Set up a counter and a list to keep track of what's been done already
-counter = 0
-done = []    
-
-#%%
-
-## In case something goofed, you should be able to just 
-## re-run this chunk with the following line filtering out 
-## what's already run. 
-
 deepest_point_assets = ee.data.listAssets({'parent': 'projects/earthengine-legacy/assets/users/sntopp/NHD/DeepestPoint'})['assets']
+## For testing on just a couple spots
+deepest_point_assets = deepest_point_assets[0:2]
 
-for i in state_dps:
-    dps = ee.FeatureCollection(i['id'])
-    id =  i['id'].split('/')[-1]
-    dpsOut = ee.batch.Export.table.toDrive(dps,id,'EE_DP_Exports',id)
-    maximum_no_of_tasks(15, 60)
-    dpsOut.start()
-
-for states in deepest_point_assets:
-    state_id = i['id'].split('/')[-1]
+for i in deepest_point_assets:
+    state_id = i['id'].split('/')[-1].split('_')[-1]
     state = states.filter(ee.Filter.eq('STUSPS',state_id)).first()
 
     ### Each state asset has overlap with neighboring states, remove overlap
-    deepest_points_state = ee.FeatureCollection(i['id']).filterBounds(state)
+    deepest_points_state = ee.FeatureCollection(i['id']).filterBounds(state.geometry())\
+        .filterMetadata('type','equals','dp')\
+        .filterMetadata('distance', "greater_than", 60)
+
+    ##For testing on tiny portion of lakes
+    deepest_points_state=deepest_points_state.randomColumn().filterMetadata('random','less_than',.05)
+
     ### Pull tiles
-    wrs_state = wrs.filterBounds(state)
-    path_rows = tiles.aggregate_array('PR').getInfo()#filterMetadata('PR', 'equals', tiles)
+    wrs_state = wrs.filterBounds(state.geometry())
+    path_rows = wrs_state.aggregate_array('PR').getInfo()
     for tiles in path_rows:
-        tile = wrs_state.filterMetadata('PR', 'equals', tiles)
+        tile = wrs_state.filterMetadata('PR', 'equals', tiles).first()
 
         lakes = deepest_points_state.filterBounds(tile.geometry())\
             .map(dpBuff)
@@ -100,16 +87,12 @@ for states in deepest_point_assets:
         out = stack.map(RefPull).flatten().filterMetadata('cScore_clouds','less_than',.5)
         dataOut = ee.batch.Export.table.toDrive(collection = out,\
                                                 description = f"{state_id}_"+str(tiles),\
-                                                folder = 'LakeReflRepo',\
+                                                folder = 'NHD_DP_LakeStacks',\
                                                 fileFormat = 'csv',\
                                                 selectors = ['Aerosol','Blue', 'Green', 'Red', 'Nir', 'Swir1', 'Swir2', 'TIR1','TIR2','pixel_qa', 'hillShadow', 'sd_NirSD','cScore_clouds','pCount_dswe3','pCount_dswe1','system:index','permanent','distance'])
         #Check how many existing tasks are running and take a break if it's >25
         maximum_no_of_tasks(25, 120)
         #Send next task.
         dataOut.start()
-        counter = counter + 1
-        done.append(tiles)
-        print('done_' + str(counter) + '_' + str(tiles))
-        
-#%%
+        print('done_' + f"{state_id}_"+str(tiles))
 

--- a/2_rsdata/src/LakeExport.py
+++ b/2_rsdata/src/LakeExport.py
@@ -37,6 +37,7 @@ dummyBands = ee.Image(-99).rename('Null_CS')\
 def addDummy(i):
     return i.addBands(dummyBands)
 
+#TODO this should all be Collection 2! Need to Updated DSWE first though.
 l8 = ee.ImageCollection('LANDSAT/LC08/C01/T1_SR')
 l7 = ee.ImageCollection('LANDSAT/LE07/C01/T1_SR')\
     .map(addDummy)
@@ -45,6 +46,7 @@ l5 = ee.ImageCollection('LANDSAT/LT05/C01/T1_SR')\
 
 #Standardize band names between the various collections and aggregate 
 #them into one image collection
+#TODO Add panchromatic band
 bn8 = ['B1','B2','B3', 'B4', 'B5','B6','B7', 'B10','B11','pixel_qa']
 bn57 = ['Null_CS', 'B1', 'B2', 'B3', 'B4', 'B5', 'B7', 'B6','Null_TIR2', 'pixel_qa']
 bns = ['Aerosol','Blue', 'Green', 'Red', 'Nir', 'Swir1', 'Swir2', 'TIR1','TIR2','pixel_qa']
@@ -59,9 +61,11 @@ ls = ee.ImageCollection(ls5.merge(ls7).merge(ls8))\
 
 deepest_point_assets = ee.data.listAssets({'parent': 'projects/earthengine-legacy/assets/users/sntopp/NHD/DeepestPoint'})['assets']
 ## For testing on just a couple spots
-deepest_point_assets = deepest_point_assets[0:2]
+#deepest_point_assets = deepest_point_assets[0:2]
 
 for i in deepest_point_assets:
+    ## Could potentially swap this and do it by state first. Might make front end filtering
+    ## Easier
     state_id = i['id'].split('/')[-1].split('_')[-1]
     state = states.filter(ee.Filter.eq('STUSPS',state_id)).first()
 

--- a/2_rsdata/src/LakeExport.py
+++ b/2_rsdata/src/LakeExport.py
@@ -6,35 +6,31 @@ Created on Tue Feb 27 12:07:02 2018
 @author: simontopp
 """
 #%%
-import time
 import ee
-import os
-#import pandas as pd
-#import feather
-ee.Initialize()
+from GEE_pull_functions import maximum_no_of_tasks
 
-#Source necessary functions.
-exec(open('C:\\Users\\mfmeyer\\OneDrive - DOI\\lake_fires\\scripts\\GEE_pull_functions.py').read())
+ee.Initialize()
 
 #water = ee.Image("JRC/GSW1_1/GlobalSurfaceWater").select('occurrence').gt(80)
 
 ## Bring in EE Assets
 # Deepest point for CONUS Hydrolakes from Xiao Yang
 # Code available https://zenodo.org/record/4136755#.X5d54pNKgUE
-dp = (ee.FeatureCollection('users/michaelfrederickmeyer/NHD_CO')
-  .filterMetadata('type','equals','dp')
-  .filterMetadata('distance', "greater_than", 60))
+#dp = (ee.FeatureCollection('users/michaelfrederickmeyer/NHD_CO')
+#  .filterMetadata('type','equals','dp')
+#  .filterMetadata('distance', "greater_than", 60))
 
 #CONUS Boundary
 us = ee.FeatureCollection("USDOS/LSIB_SIMPLE/2017")\
     .filterMetadata('country_na', 'equals', 'United States')
+
+states = ee.FeatureCollection("TIGER/2018/States")
 
 ## WRS Tiles in descending (daytime) mode for CONUS
 wrs = ee.FeatureCollection('users/sntopp/wrs2_asc_desc')\
     .filterBounds(dp)\
     .filterMetadata('MODE', 'equals', 'D')
     
-pr = wrs.aggregate_array('PR').getInfo()
 
 
 #%%
@@ -74,30 +70,46 @@ done = []
 ## In case something goofed, you should be able to just 
 ## re-run this chunk with the following line filtering out 
 ## what's already run. 
-pr = [i for i in pr if i not in done]
 
-for tiles in pr:
-    tile = wrs.filterMetadata('PR', 'equals', tiles)
-    # For some reason we need to cast this to a list and back to a
-    # feature collection
-    lakes = dp.filterBounds(tile.geometry())\
-        .map(dpBuff)
-        
-    #lakes = ee.FeatureCollection(lakes.toList(10000))
-    stack = ls.filterBounds(tile.geometry().centroid())
-    out = stack.map(RefPull).flatten().filterMetadata('cScore_clouds','less_than',.5)
-    dataOut = ee.batch.Export.table.toDrive(collection = out,\
-                                            description = str(tiles),\
-                                            folder = 'LakeReflRepo',\
-                                            fileFormat = 'csv',\
-                                            selectors = ['Aerosol','Blue', 'Green', 'Red', 'Nir', 'Swir1', 'Swir2', 'TIR1','TIR2','pixel_qa', 'hillShadow', 'sd_NirSD','cScore_clouds','pCount_dswe3','pCount_dswe1','system:index','permanent','distance'])
-    #Check how many existing tasks are running and take a break if it's >25  
-    maximum_no_of_tasks(25, 120)
-    #Send next task.
-    dataOut.start()
-    counter = counter + 1
-    done.append(tiles)
-    print('done_' + str(counter) + '_' + str(tiles))
+deepest_point_assets = ee.data.listAssets({'parent': 'projects/earthengine-legacy/assets/users/sntopp/NHD/DeepestPoint'})['assets']
+
+for i in state_dps:
+    dps = ee.FeatureCollection(i['id'])
+    id =  i['id'].split('/')[-1]
+    dpsOut = ee.batch.Export.table.toDrive(dps,id,'EE_DP_Exports',id)
+    maximum_no_of_tasks(15, 60)
+    dpsOut.start()
+
+for states in deepest_point_assets:
+    state_id = i['id'].split('/')[-1]
+    state = states.filter(ee.Filter.eq('STUSPS',state_id)).first()
+
+    ### Each state asset has overlap with neighboring states, remove overlap
+    deepest_points_state = ee.FeatureCollection(i['id']).filterBounds(state)
+    ### Pull tiles
+    wrs_state = wrs.filterBounds(state)
+    path_rows = tiles.aggregate_array('PR').getInfo()#filterMetadata('PR', 'equals', tiles)
+    for tiles in path_rows:
+        tile = wrs_state.filterMetadata('PR', 'equals', tiles)
+
+        lakes = deepest_points_state.filterBounds(tile.geometry())\
+            .map(dpBuff)
+
+        #lakes = ee.FeatureCollection(lakes.toList(10000))
+        stack = ls.filterBounds(tile.geometry().centroid())
+        out = stack.map(RefPull).flatten().filterMetadata('cScore_clouds','less_than',.5)
+        dataOut = ee.batch.Export.table.toDrive(collection = out,\
+                                                description = f"{state_id}_"+str(tiles),\
+                                                folder = 'LakeReflRepo',\
+                                                fileFormat = 'csv',\
+                                                selectors = ['Aerosol','Blue', 'Green', 'Red', 'Nir', 'Swir1', 'Swir2', 'TIR1','TIR2','pixel_qa', 'hillShadow', 'sd_NirSD','cScore_clouds','pCount_dswe3','pCount_dswe1','system:index','permanent','distance'])
+        #Check how many existing tasks are running and take a break if it's >25
+        maximum_no_of_tasks(25, 120)
+        #Send next task.
+        dataOut.start()
+        counter = counter + 1
+        done.append(tiles)
+        print('done_' + str(counter) + '_' + str(tiles))
         
 #%%
 

--- a/2_rsdata/src/LakeExport.py
+++ b/2_rsdata/src/LakeExport.py
@@ -30,7 +30,6 @@ states = ee.FeatureCollection("TIGER/2018/States")
 wrs = ee.FeatureCollection('users/sntopp/wrs2_asc_desc')\
     .filterMetadata('MODE', 'equals', 'D')
     
-#%%
 dummyBands = ee.Image(-99).rename('Null_CS')\
     .addBands(ee.Image(-99).rename('Null_TIR2'))
 
@@ -75,7 +74,7 @@ for i in deepest_point_assets:
         .filterMetadata('distance', "greater_than", 60)
 
     ##For testing on tiny portion of lakes
-    deepest_points_state=deepest_points_state.randomColumn().filterMetadata('random','less_than',.05)
+    ##deepest_points_state=deepest_points_state.randomColumn().filterMetadata('random','less_than',.05)
 
     ### Pull tiles
     wrs_state = wrs.filterBounds(state.geometry())


### PR DESCRIPTION
This PR addresses the issues raised in #1 .  Specifically it:
- Revamps the `LakeExport.py` to work with the NHD deepest points instead of HydroLakes.  Because the NHD deepest point assets are by state, it now iterates by state -> wrs tile rather than just wrs tile.  New file name format for exports is <state>_<path_row>.csv
- Adds a couple `TODO` items to start thinking about updating to collection 2
- Generally just cleans up some random code that was extraneous

@mishafredmeyer and @bellaoleksy I think this should work for fire pulls, but let me know if you have any questions. Probably worth filtering the deepest point asset stack to just your states.  Also! Keep in mind lots of the tiny NHD lakes are poorly classified (they aren't really lakes), so you might end up with some empties in there.